### PR TITLE
Jiafug v3.0.0

### DIFF
--- a/src/de/tuberlin/sese/swtpp/gameserver/model/cannon/Board.java
+++ b/src/de/tuberlin/sese/swtpp/gameserver/model/cannon/Board.java
@@ -1,6 +1,7 @@
 package de.tuberlin.sese.swtpp.gameserver.model.cannon;
 
 import java.io.Serializable;
+import java.util.HashSet;
 
 public class Board implements Serializable {
 
@@ -12,9 +13,12 @@ public class Board implements Serializable {
 	private int[][] board = new int[10][10];
 	private CannonGame game;
 	private final String letterIndex = "abcdefghij";
+	private HashSet<String> possibleMoves;
 
 	public Board(CannonGame game) {
 		this.game = game;
+		this.possibleMoves = new HashSet<>();
+
 	}
 
 	// [0][0] ist das Feld oben links, also a9, [9][9] ist j0 um mit dem
@@ -30,13 +34,13 @@ public class Board implements Serializable {
 			for (int j = 0; j < 10; j++) {
 				if (board[i][j] == 0)
 					tmp = tmp + "1";
-				else if (board[i][j] == 1)
+				if (board[i][j] == 1)
 					tmp = tmp + "w";
-				else if (board[i][j] == 2)
+				if (board[i][j] == 2)
 					tmp = tmp + "W";
-				else if (board[i][j] == -1)
+				if (board[i][j] == -1)
 					tmp = tmp + "b";
-				else if (board[i][j] == -2)
+				if (board[i][j] == -2)
 					tmp = tmp + "B";
 			}
 			if (tmp.contentEquals("1111111111"))
@@ -79,6 +83,7 @@ public class Board implements Serializable {
 	}
 
 	public void setBoard(String fen) {
+		board = new int[10][10];
 		int iCount = 0;
 		int jCount = 0;
 		for (int f = 0; f < fen.length(); f++) {
@@ -92,34 +97,34 @@ public class Board implements Serializable {
 				iCount++;
 			}
 			// eine Reihe weiter am Ende
-			else if (c == '/' && jCount != 0) {
+			if (c == '/' && jCount != 0) {
 				iCount++;
 				jCount = 0;
 			}
 			// Null Feld
-			else if (space > 0 && space < 10) {
+			if (space > 0 && space < 10) {
 				for (int i = 0; i < space; i++) {
 					board[iCount][jCount] = 0;
 					jCount++;
 				}
 			}
 			// Schwarz Soldat
-			else if (c == 'b') {
+			if (c == 'b') {
 				board[iCount][jCount] = -1;
 				jCount++;
 			}
 			// Schwarz Stadt
-			else if (c == 'B') {
+			if (c == 'B') {
 				board[iCount][jCount] = -2;
 				jCount++;
 			}
 			// Weiss Soldat
-			else if (c == 'w') {
+			if (c == 'w') {
 				board[iCount][jCount] = 1;
 				jCount++;
 			}
 			// Weiss Stadt
-			else if (c == 'W') {
+			if (c == 'W') {
 				board[iCount][jCount] = 2;
 				jCount++;
 			}
@@ -143,22 +148,72 @@ public class Board implements Serializable {
 	 */
 	public boolean performMove(String move) {
 		// Berechnet die Position im board-Array
+		if (this.possibleMoves.contains(move)) {
+			this.possibleMoves.clear();
+			int startX = letterIndex.indexOf(move.charAt(0));
+			int startY = Math.abs(Character.getNumericValue(move.charAt(1)) - 9);
+			int destX = letterIndex.indexOf(move.charAt(3));
+			int destY = Math.abs(Character.getNumericValue(move.charAt(4)) - 9);
+			// Ueberprueft ob die zu bewegene Figur die richtige Farbe hat und
+			// welche Zuege moeglich sind
+			if (cannonAttack(startX, startY, destX, destY)) {
+				board[destY][destX] = 0;
+				return true;
+			} else if (game.isWhiteNext()) {
+				board[startY][startX] = 0;
+				board[destY][destX] = 1;
+				return true;
+			} else {
+				board[startY][startX] = 0;
+				board[destY][destX] = -1;
+				return true;
+			}
+		} else
+			return false;
+	}
+
+	/**
+	 * finds and saves all possible moves in a hash map
+	 */
+	public HashSet<String> allPossibleMoves() {
+		String move = "";
+		for (char c : letterIndex.toCharArray()) {
+			for (int i = 0; i < 10; i++) {
+				move = String.valueOf(c) + i + "-";
+				allPossibleMovesHelper(move);
+				move = "";
+			}
+		}
+		return this.possibleMoves;
+	}
+
+	/**
+	 * method to reduce the nested block depth of anyMovePossible()
+	 */
+	private void allPossibleMovesHelper(String move) {
+		for (char c : letterIndex.toCharArray()) {
+			for (int i = 0; i < 10; i++) {
+				move += String.valueOf(c) + i;
+				if (checkMove(move))
+					possibleMoves.add(move);
+				move = move.substring(0, 3);
+			}
+		}
+	}
+
+	/**
+	 * checks weather a move is possible
+	 */
+	private boolean checkMove(String move) {
 		int startX = letterIndex.indexOf(move.charAt(0));
 		int startY = Math.abs(Character.getNumericValue(move.charAt(1)) - 9);
 		int destX = letterIndex.indexOf(move.charAt(3));
 		int destY = Math.abs(Character.getNumericValue(move.charAt(4)) - 9);
-		// Ueberprueft ob die zu bewegene Figur die richtige Farbe hat und
-		// welche Zuege moeglich sind
 		if (checkWhite(startX, startY, destX, destY)) {
-			board[startY][startX] = 0;
-			board[destY][destX] = 1;
 			return true;
 		} else if (checkBlack(startX, startY, destX, destY)) {
-			board[startY][startX] = 0;
-			board[destY][destX] = -1;
 			return true;
 		} else if (cannonAttack(startX, startY, destX, destY)) {
-			board[destY][destX] = 0;
 			return true;
 		} else
 			return false;
@@ -168,21 +223,21 @@ public class Board implements Serializable {
 	 * method to reduce the cyclomatic complexity of performMove(String move)
 	 */
 	private boolean checkWhite(int startX, int startY, int destX, int destY) {
-		return (game.isWhiteNext() && (board[startY][startX] == 1) && (simpleMove(startX, startY, destX, destY)
-				|| attackMove(startX, startY, destX, destY) || retreatMove(startX, startY, destX, destY) 
-				|| cannonMove(startX, startY, destX, destY)));
+		return (game.isWhiteNext() && (board[startY][startX] == 1)
+				&& (simpleMove(startX, startY, destX, destY) || attackMove(startX, startY, destX, destY)
+						|| retreatMove(startX, startY, destX, destY) || cannonMove(startX, startY, destX, destY)));
 	}
 
 	/**
 	 * method to reduce the cyclomatic complexity of performMove(String move)
 	 */
 	private boolean checkBlack(int startX, int startY, int destX, int destY) {
-		return (!game.isWhiteNext() && (board[startY][startX] == -1) && (simpleMove(startX, startY, destX, destY)
-				|| attackMove(startX, startY, destX, destY) || retreatMove(startX, startY, destX, destY) 
-				|| cannonMove(startX, startY, destX, destY)));
+		return (!game.isWhiteNext() && (board[startY][startX] == -1)
+				&& (simpleMove(startX, startY, destX, destY) || attackMove(startX, startY, destX, destY)
+						|| retreatMove(startX, startY, destX, destY) || cannonMove(startX, startY, destX, destY)));
 	}
 
-/**
+	/**
 	 * checks if a simple move is possible
 	 */
 	private boolean simpleMove(int startX, int startY, int destX, int destY) {
@@ -209,8 +264,9 @@ public class Board implements Serializable {
 			var = -1;
 		else
 			var = 1;
-		return (destX == startX - 1 || destX == startX + 1) && (destY == startY)
-				&& (board[destY][destX] == var || board[destY][destX] == var * 2);
+		if (board[destY][destX] == var * 2)
+			var = var * 2;
+		return (destX == startX - 1 || destX == startX + 1) && (destY == startY) && (board[destY][destX] == var);
 	}
 
 	/**
@@ -220,18 +276,24 @@ public class Board implements Serializable {
 		// Ueberprueft ob das Zielfeld leer ist und keine Figur im Weg steht und
 		// ob der Schritt genau zwei Felder nach hinten gerade oder diagonal
 		// verlaeuft
-		int var;
-		if (game.isWhiteNext())
-			var = -1;
-		else
-			var = 1;
-		return (board[destY][destX] == 0
-				&& (destY == startY + (2 * var) && (board[startY + 1][startX] == var || board[startY][startX - 1] == var
-						|| board[startY + 1][startX - 1] == var || board[startY][startX + 1] == var
-						|| board[startY + 1][startX + 1] == var || board[startY - 1][startX] == var
-						|| board[startY - 1][startX - 1] == var || board[startY - 1][startX + 1] == var))
-				&& (destX == startX - 2 || destX == startX + 2 || destX == startX)
-				&& board[(destY + startY) / 2][(destX + startX) / 2] == 0);
+		try {
+			int var;
+			if (game.isWhiteNext())
+				var = -1;
+			else
+				var = 1;
+			return (board[destY][destX] == 0
+					&& (destY == startY + (2 * var)
+							&& (board[startY + 1][startX] == var || board[startY][startX - 1] == var
+									|| board[startY + 1][startX - 1] == var || board[startY][startX + 1] == var
+									|| board[startY + 1][startX + 1] == var || board[startY - 1][startX] == var
+									|| board[startY - 1][startX - 1] == var || board[startY - 1][startX + 1] == var))
+					&& (destX == startX - 2 || destX == startX + 2 || destX == startX)
+					&& board[(destY + startY) / 2][(destX + startX) / 2] == 0);
+		} catch (ArrayIndexOutOfBoundsException e) {
+			return false;
+		}
+
 	}
 
 	/**
@@ -262,7 +324,6 @@ public class Board implements Serializable {
 						&& board[startY][startX - 2] == var
 				|| (destY - startY == 3) && (destX - startX == -3) && board[startY + 1][startX - 1] == var
 						&& board[startY + 2][startX - 2] == var)));
-
 	}
 
 	/**

--- a/src/de/tuberlin/sese/swtpp/gameserver/model/cannon/CannonGame.java
+++ b/src/de/tuberlin/sese/swtpp/gameserver/model/cannon/CannonGame.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import de.tuberlin.sese.swtpp.gameserver.model.Game;
+import de.tuberlin.sese.swtpp.gameserver.model.Move;
 import de.tuberlin.sese.swtpp.gameserver.model.Player;
 
 /**
@@ -235,24 +236,40 @@ public class CannonGame extends Game implements Serializable {
 		board.setBoard(state);
 	}
 
+	private void checkPossibleMoves() {
+		if (board.allPossibleMoves().size() == 0) {
+			if (isWhiteNext())
+				finish(blackPlayer);
+			else
+				finish(whitePlayer);
+		}
+	}
+
 	@Override
 	public String getBoard() {
+		checkPossibleMoves();
 		String state = board.getBoard();
-		if (blackTownSet && ((state.contains("W") && !state.contains("B")) || blackGaveUp()))
+		if (state.contains("W"))
+			whiteTownSet = true;
+		if (state.contains("B"))
+			blackTownSet = true;
+		if (blackTownSet && whiteTownSet && !state.contains("B"))
 			finish(whitePlayer);
-		else if (whiteTownSet && ((!state.contains("W") && state.contains("B")) || whiteGaveUp()))
+		if (whiteTownSet && blackTownSet && !state.contains("W"))
 			finish(blackPlayer);
-		System.out.println(state);
 		return state;
 	}
 
 	@Override
 	public boolean tryMove(String moveString, Player player) {
+		checkPossibleMoves();
 		String state = board.getBoard();
 		if ((!whiteTownSet && !state.contains("W")) || (!blackTownSet && !state.contains("B")))
 			return setTown(moveString, player);
 		if (board.performMove(moveString)) {
+			history.add(new Move(moveString, state, player));
 			updateNext();
+			getBoard();
 			return true;
 		} else
 			return false;

--- a/src/de/tuberlin/sese/swtpp/gameserver/test/cannon/TryMoveTest.java
+++ b/src/de/tuberlin/sese/swtpp/gameserver/test/cannon/TryMoveTest.java
@@ -14,41 +14,41 @@ public class TryMoveTest {
 
 	User user1 = new User("Alice", "alice");
 	User user2 = new User("Bob", "bob");
-	
+
 	Player whitePlayer = null;
 	Player blackPlayer = null;
 	CannonGame game = null;
 	GameController controller;
-	
+
 	@Before
 	public void setUp() throws Exception {
 		controller = GameController.getInstance();
 		controller.clear();
-		
+
 		int gameID = controller.startGame(user1, "");
-		
+
 		game = (CannonGame) controller.getGame(gameID);
 		whitePlayer = game.getPlayer(user1);
 
 	}
-	
+
 	public void startGame(String initialBoard, boolean whiteNext) {
-		controller.joinGame(user2);		
+		controller.joinGame(user2);
 		blackPlayer = game.getPlayer(user2);
-		
+
 		game.setBoard(initialBoard);
-		game.setNextPlayer(whiteNext? whitePlayer:blackPlayer);
+		game.setNextPlayer(whiteNext ? whitePlayer : blackPlayer);
 	}
-	
+
 	public void assertMove(String move, boolean white, boolean expectedResult) {
 		if (white)
 			assertEquals(expectedResult, game.tryMove(move, whitePlayer));
-		else 
-			assertEquals(expectedResult,game.tryMove(move, blackPlayer));
+		else
+			assertEquals(expectedResult, game.tryMove(move, blackPlayer));
 	}
-	
+
 	public void assertGameState(String expectedBoard, boolean whiteNext, boolean finished, boolean whiteWon) {
-		assertEquals(expectedBoard,game.getBoard().replaceAll("e", ""));
+		assertEquals(expectedBoard, game.getBoard().replaceAll("e", ""));
 		assertEquals(whiteNext, game.isWhiteNext());
 
 		assertEquals(finished, game.isFinished());
@@ -59,18 +59,144 @@ public class TryMoveTest {
 			assertEquals(!whiteWon, blackPlayer.isWinner());
 		}
 	}
-	
 
 	/*******************************************
 	 * !!!!!!!!! To be implemented !!!!!!!!!!!!
 	 *******************************************/
-	
+
 	@Test
 	public void exampleTest() {
-		startGame("5W4/1w1w1w1w1w/1w1w1w1w1w/1w3w1w1w/2w7/5b4/b1b3b1b1/b1b1b1b1b1/b1b1b1b1b1/3B6",true);
-		assertMove("h6-h5",true,true);
-		assertGameState("5W4/1w1w1w1w1w/1w1w1w1w1w/1w3w3w/2w4w2/5b4/b1b3b1b1/b1b1b1b1b1/b1b1b1b1b1/3B6",false,false,false);
+		startGame("5W4/1w1w1w1w1w/1w1w1w1w1w/1w3w1w1w/2w7/5b4/b1b3b1b1/b1b1b1b1b1/b1b1b1b1b1/3B6", true);
+		assertMove("h6-h5", true, true);
+		assertGameState("5W4/1w1w1w1w1w/1w1w1w1w1w/1w3w3w/2w4w2/5b4/b1b3b1b1/b1b1b1b1b1/b1b1b1b1b1/3B6", false, false,
+				false);
 	}
 
-	//TODO: implement test cases of same kind as example here
+	// TODO: implement test cases of same kind as example here
+
+	@Test
+	public void setTownTest() {
+		startGame("/1w1w1w1w1w/1w1w1w1w1w/1w1w1w1w1w///b1b1b1b1b1/b1b1b1b1b1/b1b1b1b1b1/", true);
+		assertMove("a8-a8", true, false);
+		assertMove("c9-c9", true, true);
+		assertMove("d3-d3", false, false);
+		assertMove("f0-f0", false, true);
+		assertGameState("2W7/1w1w1w1w1w/1w1w1w1w1w/1w1w1w1w1w///b1b1b1b1b1/b1b1b1b1b1/b1b1b1b1b1/5B4", true, false,
+				false);
+	}
+
+	@Test
+	public void moveTest1() {
+		startGame("2W7/1w1w1w1w1w/1w1w1w1w1w/1w1w1w1w1w///b1b1b1b1b1/b1b1b1b1b1/b1b1b1b1b1/5B4", true);
+		assertMove("d8-d5", true, true);
+		assertMove("g1-f2", false, true);
+		assertMove("d7-d6", true, false);
+		assertMove("f6-e5", true, true);
+		assertMove("e1-e5", false, true);
+		assertGameState("2W7/1w3w1w1w/1w1w1w1w1w/1w1w3w1w/3w6//b1b1b1b1b1/b1b1bbb1b1/b1b1b3b1/5B4", true, false, false);
+	}
+
+	@Test
+	public void moveTest2() {
+		startGame("4W5/1w1w1w1w1w/1w1w1w1w1w/1w1w1w1w1w///b1b1b1b1b1/b1b1b1b1b1/b1b1b1b1b1/4B5", true);
+		assertMove("f7-e6", true, true);
+		assertMove("e3-f4", false, true);
+		assertMove("f6-f5", true, true);
+		assertMove("g1-f2", false, true);
+		assertMove("f5-e4", true, true);
+		assertMove("f4-e5", false, true);
+		assertMove("d6-d5", true, true);
+		assertMove("c1-d2", false, true);
+		assertMove("f8-f7", true, true);
+		assertMove("c3-c4", false, true);
+		assertGameState("4W5/1w1w3w1w/1w1w1w1w1w/1w2w2w1w/3wb5/2b1w5/b5b1b1/b1bbbbb1b1/b3b3b1/4B5", true, false, false);
+	}
+
+	@Test
+	public void moveTest3() {
+		startGame("4W5/1w1w3w1w/1w1w3w1w/1w3w1w1w/3bwww3/4b5/b1b1b1b1b1/b1b1b1b1b1/b5b1b1/4B5", false);
+		assertMove("c2-d3", false, true);
+		assertMove("f5-e4", true, true);
+		assertMove("c3-d4", false, true);
+		assertMove("d7-e6", true, true);
+		assertMove("d5-e6", false, true);
+		assertMove("d8-e7", true, true);
+		assertMove("e6-e7", false, true);
+		assertMove("e4-d4", true, true);
+		assertMove("e7-d8", false, true);
+		assertMove("e5-e4", true, true);
+		assertMove("d8-e9", false, true);
+		assertGameState("4b5/1w5w1w/1w5w1w/1w3w1w1w/6w3/3ww5/b2bb1b1b1/b3b1b1b1/b5b1b1/4B5", true, true, false);
+	}
+
+	@Test
+	public void moveTest4() {
+		startGame("4W5/1w3w1w1w/1w1ww2w1w/1w1w2ww1w/6w3/7b2/b1b1b3b1/b1b1bbb1bb/b1b3b3/3B6", true);
+		assertMove("g5-f4", true, true);
+		assertMove("j2-g5", false, true);
+		assertMove("g6-g5", true, true);
+		assertMove("c1-d2", false, true);
+		assertMove("f4-i7", true, true);
+		assertMove("e3-e4", false, true);
+		assertMove("h8-g7", true, true);
+		assertMove("d2-d3", false, true);
+		assertMove("h7-g6", true, true);
+		assertMove("c2-f5", false, true);
+		assertMove("e7-e6", true, true);
+		assertMove("h4-i5", false, true);
+		assertMove("g6-f5", true, true);
+		assertMove("g2-g3", false, true);
+		assertMove("g5-g4", true, true);
+		assertMove("e2-e3", false, true);
+		assertMove("f5-f4", true, true);
+		assertMove("g3-g4", false, true);
+		assertMove("f4-f3", true, true);
+		assertMove("c3-f3", false, false);
+		assertMove("f2-f3", false, true);
+		assertMove("b8-b5", true, true);
+		assertMove("f3-f4", false, true);
+		assertMove("b5-b4", true, true);
+		assertMove("i3-i4", false, true);
+		assertMove("b4-b3", true, true);
+		assertGameState("4W5/5w3w/1w1w2w1ww/1w1ww2w1w/8b1/4bbb1b1/bwbbb5/b7b1/b5b3/3B6", false, false, false);
+	}
+
+	@Test
+	public void stateTest1() {
+		startGame("/1w3w1w1w/1w1ww2w1w/1w1w2ww1w/6w3/7b2/b1b1b3b1/b1b1bbb1bb/b1b3b3/3B6", true);
+		assertMove("b8-b5", true, false);
+		assertGameState("/1w3w1w1w/1w1ww2w1w/1w1w2ww1w/6w3/7b2/b1b1b3b1/b1b1bbb1bb/b1b3b3/3B6", true, false, false);
+	}
+
+	@Test
+	public void stateTest2() {
+		startGame("3W6/1w3w1w1w/1w1ww2w1w/1w1w2ww1w/6w3/7b2/b1b1b3b1/b1b1bbb1bb/b1b3b3/", false);
+		assertMove("b8-b5", true, false);
+		assertGameState("3W6/1w3w1w1w/1w1ww2w1w/1w1w2ww1w/6w3/7b2/b1b1b3b1/b1b1bbb1bb/b1b3b3/", false, false, false);
+	}
+
+	@Test
+	public void stateTest3() {
+		startGame("4W5/1w1w3w1w/1w1w3w1w/1w1w3w1w/2b7/2b2w4/b1b1bwb1b1/b3b1b1b1/b3w1b1b1/3B6", false);
+		assertMove("g1-g4", false, true);
+		assertMove("e1-d0", true, true);
+		assertGameState("4W5/1w1w3w1w/1w1w3w1w/1w1w3w1w/2b7/2b2wb3/b1b1bwb1b1/b3b1b1b1/b7b1/3w6", false, true, true);
+	}
+
+	@Test
+	public void stateTest4() {
+		startGame("b1b1W5/9b/////5w4/7ww1//w2B6", true);
+		assertMove("f3-e2", true, true);
+		assertMove("j8-j9", false, true);
+		assertMove("i2-i1", true, true);
+		assertGameState("b1b1W4b///////4w2w2/8w1/w2B6", false, true, true);
+	}
+
+	@Test
+	public void stateTest5() {
+		startGame("b1b1W5/9b/////5b4/7bb1/9w/w2B6", true);
+		assertMove("j1-i0", true, true);
+		assertMove("h2-h3", false, true);
+		assertGameState("b1b1W5/9b/////5b1b2/8b1//w2B4w1", true, true, false);
+	}
 }


### PR DESCRIPTION
## **jUnit-Tests und Bugfixes**

**tl;dr**
- 100% Branch Coverage 
- letzte Winning Condition (c) implementiert - winning conditions #10 
- verschiedene Fehler behoben
- letztes funktionale Update!?

### **Board Klasse**
- `getBoard()`: verschachtelte `if else` Anweisung in einzelne `if` Anweisung aufgeteilt, um einfacher 100 % Branch Coverage zu erreichen
- `setBoard()`: beim jedem neuen initialisieren des Boards wird das `board` Array zurückgesetzt; 
vor allem wichtig für `startGame(String, boolean)` der `TryMoveTest` Klasse
- `setBoard()`: verschachtelte `if else` Anweisung in einzelne `if` Anweisung aufgeteilt, um einfacher 100 % Branch Coverage zu erreichen
- `allPossibleMoves()` & `allPossibleMovesHelper(String)` & `checkMove(String)`: neue Methoden, die alle möglichen Spielzüge eines Spielers bestimmt und diese als MoveString in die HashMap `possibleMoves` gespeichert
- `performMove(String)`: statt jeden einzelnen Zug zu überprüfen, ob dieser valide ist, wird überprüft, ob der übergebene MoveString in der HashMap `possibleMoves` enthalten ist;
einzige Ausnahme ist der Kanonenschuss (wird am ganz am Anfang auf die herkömmliche Art geprüft)
- `attackMove(int, int, int, int)`: Fehler behoben, der es ermöglicht hat, die Stadt aus jeder beliebigen Position direkt anzugreifen  
- `retreatMove(int, int, int, int)`: try-catch Block hinzugefügt, um `ArrayIndexOutOfBoundsException` abzufangen, die eventuell von `checkMove(String)` erzeugt werden

### **CannonGame Klasse**
- `checkPossibleMoves()`: neue Klasse, die überprüft, ob der Spieler noch valide Züge durchführen kann; falls nicht hat der Spieler verloren
- `getBoard()`: überprüft am Anfang ob immer noch Züge durchführbar sind;
der Städte Boolean Flag (`whiteTownSet` & `blackTownSet`) wird jetzt richtig gesetzt (bei einem vordefinierten Board State); 
es wird nicht mehr durch diese Methode überprüft, ob ein Spieler aufgegeben hat (wird schon standardmäßig überprüft)
- `tryMove()`: überprüft am Anfang ob immer noch Züge durchführbar sind;
die Spiel History (aus der Superklasse` Game`: `List<Move> history`) wird jetzt auch unterstützt;
Aufruf von `getBoard()` nach einem erfolgreichen Zug um zuverlässiger die Niederlagebedingungen zu überprüfen 

### **TryMoveTest Klasse**
- verschiedene jUnit-Tests implementiert um 100% Branch Coverage zu erreichen
